### PR TITLE
Make Spreedly::client() public 

### DIFF
--- a/src/Spreedly.php
+++ b/src/Spreedly.php
@@ -118,7 +118,7 @@ class Spreedly
      *
      * @return \GuzzleHttp\Client
      */
-    protected function client()
+    public function client()
     {
         return new Client(new Guzzle(), $this->config);
     }


### PR DESCRIPTION
Make Spreedly::client() public so we can access the raw Guzzle interface for calls this library doesn't natively support (#27)